### PR TITLE
Make recent ocaml compile

### DIFF
--- a/generator/generator.ml
+++ b/generator/generator.ml
@@ -12,7 +12,7 @@
 
 (** {1 XSD validator generator} *)
 
-let version = String.copy "0.2"
+let version = "0.2"
 
 
 let read_commandline () =

--- a/lib/file_in.ml
+++ b/lib/file_in.ml
@@ -69,13 +69,13 @@ let of_string s extension_l =
       raise (Error.E Error.F_wrong_input_file)
     else
       let extension = get_extension  s extension_l in
-      In ((String.copy s), extension)
+      In (s, extension)
 
 
 (** Return the file name corresponding to an input file value.
    @raise Error.E [Error.F_wrong_printing_file_extension] *)
 let to_string (In (s,_)) =
-  Filename.quote (String.copy s)
+  Filename.quote s
 
 
 (** Record the opened input channels and close the recoreded openend

--- a/lib/file_out.ml
+++ b/lib/file_out.ml
@@ -33,7 +33,7 @@ let suffix = function
   | Log -> ".log"
 
 (** Name of the generator library directory. *)
-let generator_lib_dir = String.copy "xsvgen_lib"
+let generator_lib_dir = "xsvgen_lib"
 
 
 (** Return an output name value from a given debug mode and a given
@@ -52,7 +52,7 @@ let of_string debug s =
   then
     raise (Error.E Error.F_wrong_output_basename)
   else
-    Out ((String.copy out_s),debug)
+    Out (out_s,debug)
 
 (** Perform a preparation of the output directory, for a given
     name "xsval":

--- a/lib/message_debug.ml
+++ b/lib/message_debug.ml
@@ -1114,7 +1114,7 @@ end
 
 
 
-let pr_fun mtype loc descr_fun descr =
+let pr_fun (mtype: mtype) loc descr_fun descr =
   Format.fprintf !log_formatter "[%s] %a%s@."
     (match mtype with
     | Error -> "error"

--- a/lib/message_debug.ml
+++ b/lib/message_debug.ml
@@ -723,10 +723,10 @@ module Pr_error = struct
     " [SCC " ^ (string_of_scc r) ^ "]"
 
   let sec () =
-    String.copy " (security constraint)"
+    " (security constraint)"
 
   let lim () =
-    String.copy " (limitation)"
+    " (limitation)"
 
   let string_of_xsdl_def = function
     | Error.XSDLDEF_type ->

--- a/lib/message_silent.ml
+++ b/lib/message_silent.ml
@@ -104,9 +104,9 @@ module Pr_debug = struct
   let fp_utf8_range _ _ =
     ()
   let hex_string_of_string _ =
-    String.copy ""
+    ""
   let string_hex_of_string _ =
-    String.copy ""
+    ""
   let string_of_lexeme _ =
-    String.copy ""
+    ""
 end

--- a/lib/stringdata.ml
+++ b/lib/stringdata.ml
@@ -144,10 +144,8 @@ let chars_part_to_string (pos,lim) (p_pos,p_lim) offset source =
     | In_channel (ic,_) ->
         begin
           try
-            let s = String.make len '\000' in
             seek_in ic srcoff;
-            really_input ic s 0 len;
-            s
+            really_input_string ic len;
           with
           | End_of_file
           | Invalid_argument _ ->

--- a/lib/stringdata.ml
+++ b/lib/stringdata.ml
@@ -1007,14 +1007,14 @@ let to_code_escaped_string sd =
     else calc_len (i + 1) (ri + 4)
   in
   let rlen = calc_len 0 0 in
-  let rs = String.make rlen ' ' in
+  let rs = Bytes.make rlen ' ' in
   let rec pr_char i ri =
     if i >= len
-    then rs
+    then Bytes.to_string rs
     else if s.[i] >= '\032' && s.[i] <= '\126'
     then
       begin
-        rs.[ri] <- s.[i];
+        Bytes.set rs ri s.[i];
         pr_char (i + 1) (ri + 1)
       end
     else

--- a/lib/stringdata.ml
+++ b/lib/stringdata.ml
@@ -117,14 +117,13 @@ let of_in_channel ic file_name =
     @raise Error.E [Error.SD_structure]
  *)
 let of_string s =
-  let s_copy = String.copy s in
-  let length = String.length s_copy in
-  { source = String (s_copy);
+  let length = String.length s in
+  { source = String (s);
     parts = Parts.singleton {p_position=0;p_limit=length} (Chars 0);
     exp_position = 0;
     loc_position = 0;
     exp_limit = length;
-    access = (fun i -> try s_copy.[i] with
+    access = (fun i -> try s.[i] with
                        | Invalid_argument _ ->
                            raise (Error.E Error.SD_structure) ) }
 
@@ -198,7 +197,7 @@ let to_string = function
                 s2 ^ s1
               end)
           parts
-          (String.copy "")
+          ("")
 
 (** Return an integer value out of a given string data, return [None]
     if the given string data is not a valid representation of an integer,

--- a/lib/utf8.ml
+++ b/lib/utf8.ml
@@ -373,26 +373,31 @@ let empty =
 
 (** Minimum continuation byte *)
 let min_continuation_byte = Char.chr 0x80
+
 (** Maximum continuation byte *)
 let max_continuation_byte = Char.chr 0xBF
 
 (** Minimum first byte of a 1-byte character *)
 let min_1byte_b1 = Char.chr 0x01
+
 (** Maximum first byte of a 1-byte character *)
 let max_1byte_b1 = Char.chr 0x7F
 
 (** Minimum first byte of a 2-bytes character *)
 let min_2bytes_b1 = Char.chr 0xC0
+
 (** Maximum first byte of a 2-bytes character *)
 let max_2bytes_b1 = Char.chr 0xDF
 
 (** Minimum first byte of a 3-bytes character *)
 let min_3bytes_b1 = Char.chr 0xE0
+
 (** Maximum first byte of a 3-bytes character *)
 let max_3bytes_b1 = Char.chr 0xEF
 
 (** Minimum first byte of a 4-bytes character *)
 let min_4bytes_b1 = Char.chr 0xF0
+
 (** Maximum first byte of a 4-bytes character *)
 let max_4bytes_b1 = Char.chr 0xF7
 

--- a/xsd/code_generator.ml
+++ b/xsd/code_generator.ml
@@ -50,7 +50,7 @@ let gen_Int f i =
 
 let gen_Bool f b =
   Format.fprintf f "%s"
-    (if b then String.copy "true" else String.copy "false")
+    (if b then "true" else "false")
 
 let gen_Param f wrapped_fprintf =
   Format.fprintf f "@[%a@]"


### PR DESCRIPTION
I tried to make the codebase compliant to the latest OCaml version. This had all to with how String has become immutable in later versions.

And it also seems that OCaml have been stricter in where and how odoc can written.